### PR TITLE
xop: Fix a alloc-dealloc-mismatch reported by ASAN

### DIFF
--- a/src/xop/media.h
+++ b/src/xop/media.h
@@ -31,14 +31,14 @@ enum FrameType
 struct AVFrame
 {	
 	AVFrame(uint32_t size = 0)
-		:buffer(new uint8_t[size + 1], std::default_delete< uint8_t[]>())
+		:buffer(new uint8_t[size + 1])
 	{
 		this->size = size;
 		type = 0;
 		timestamp = 0;
 	}
 
-	std::shared_ptr<uint8_t> buffer; /* 帧数据 */
+	std::shared_ptr<uint8_t[]> buffer; /* 帧数据 */
 	uint32_t size;				     /* 帧大小 */
 	uint8_t  type;				     /* 帧类型 */	
 	int64_t timestamp;		  	     /* 时间戳 */


### PR DESCRIPTION
The `buffer` shared_ptr is reset at various places without specifying the deleter as in the constructor of `AVFrame`.
This leads to operator delete being called after the reset since the shared_ptr content was not defined as array type.
Use the correct array type (`uint8_t[]`) while defining the shared_ptr so the correct deleter is selected automatically.

Reported error by ASAN:
```
==3864499==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x61a000010280
   #0 0x7f0c9c86bf7f in operator delete(void*, unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.6+0xb2f7f)
   #1 0x5617545b83b6 in std::_Sp_counted_ptr<unsigned char*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/include/c++/10/bits/shared_ptr_base.h:380
   #2 0x5617544b224e in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/10/bits/shared_ptr_base.h:158
   #3 0x5617544b0beb in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/10/bits/shared_ptr_base.h:733
   #4 0x5617545b6c13 in std::__shared_ptr<unsigned char, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/10/bits/shared_ptr_base.h:1183
   #5 0x5617545b6c33 in std::shared_ptr<unsigned char>::~shared_ptr() /usr/include/c++/10/bits/shared_ptr.h:121
   #6 0x5617545b6d3b in xop::AVFrame::~AVFrame() /home/iconnor/sandbox/ZoneMinder.zma_to_thread/dep/RtspServer/src/xop/media.h:31
```