### PR TITLE
xop: Use vector as buffer in AVFrame

### DIFF
--- a/src/xop/AACSource.cpp
+++ b/src/xop/AACSource.cpp
@@ -86,7 +86,7 @@ string AACSource::GetAttribute()  // RFC 3640
 
 bool AACSource::HandleFrame(MediaChannelId channel_id, AVFrame frame)
 {
-	if (frame.size > (MAX_RTP_PAYLOAD_SIZE-AU_SIZE)) {
+	if (frame.buffer.size() > (MAX_RTP_PAYLOAD_SIZE-AU_SIZE)) {
 		return false;
 	}
 
@@ -95,8 +95,8 @@ bool AACSource::HandleFrame(MediaChannelId channel_id, AVFrame frame)
 		adts_size = ADTS_SIZE;
 	}
 
-	uint8_t *frame_buf = frame.buffer.get() + adts_size; 
-	uint32_t frame_size = frame.size - adts_size;
+	uint8_t *frame_buf = frame.buffer.data() + adts_size;
+	uint32_t frame_size = frame.buffer.size() - adts_size;
 
 	char AU[AU_SIZE] = { 0 };
 	AU[0] = 0x00;

--- a/src/xop/G711ASource.cpp
+++ b/src/xop/G711ASource.cpp
@@ -47,12 +47,12 @@ string G711ASource::GetAttribute()
 
 bool G711ASource::HandleFrame(MediaChannelId channel_id, AVFrame frame)
 {
-	if (frame.size > MAX_RTP_PAYLOAD_SIZE) {
+	if (frame.buffer.size() > MAX_RTP_PAYLOAD_SIZE) {
 		return false;
 	}
 
-	uint8_t *frame_buf  = frame.buffer.get();
-	uint32_t frame_size = frame.size;
+	uint8_t *frame_buf  = frame.buffer.data();
+	uint32_t frame_size = frame.buffer.size();
 
 	RtpPacket rtp_pkt;
 	rtp_pkt.type = frame.type;

--- a/src/xop/H264Source.cpp
+++ b/src/xop/H264Source.cpp
@@ -49,8 +49,8 @@ string H264Source::GetAttribute()
 
 bool H264Source::HandleFrame(MediaChannelId channel_id, AVFrame frame)
 {
-    uint8_t* frame_buf  = frame.buffer.get();
-    uint32_t frame_size = frame.size;
+    uint8_t* frame_buf  = frame.buffer.data();
+    uint32_t frame_size = frame.buffer.size();
 
     if (frame.timestamp == 0) {
 	    frame.timestamp = GetTimestamp();

--- a/src/xop/H265Source.cpp
+++ b/src/xop/H265Source.cpp
@@ -49,8 +49,8 @@ string H265Source::GetAttribute()
 
 bool H265Source::HandleFrame(MediaChannelId channelId, AVFrame frame)
 {
-	uint8_t *frame_buf  = frame.buffer.get();
-	uint32_t frame_size = frame.size;
+	uint8_t *frame_buf  = frame.buffer.data();
+	uint32_t frame_size = frame.buffer.size();
 
 	if (frame.timestamp == 0) {
 		frame.timestamp = GetTimestamp();

--- a/src/xop/media.h
+++ b/src/xop/media.h
@@ -4,7 +4,8 @@
 #ifndef XOP_MEDIA_H
 #define XOP_MEDIA_H
 
-#include <memory>
+#include <cstdint>
+#include <vector>
 
 namespace xop
 {
@@ -31,16 +32,14 @@ enum FrameType
 struct AVFrame
 {	
 	AVFrame(uint32_t size = 0)
-		:buffer(new uint8_t[size + 1])
 	{
-		this->size = size;
+		buffer.reserve(size);
 		type = 0;
 		timestamp = 0;
 	}
 
-	std::shared_ptr<uint8_t[]> buffer; /* 帧数据 */
-	uint32_t size;				     /* 帧大小 */
-	uint8_t  type;				     /* 帧类型 */	
+	std::vector<uint8_t> buffer;     /* 帧数据 */
+	uint8_t  type;				     /* 帧类型 */
 	int64_t timestamp;		  	     /* 时间戳 */
 };
 


### PR DESCRIPTION
This is change is intended to fix a build failure encountered on clang
10 with 6a0bcdfb33eafbd44ab84d336f3259131918a8d9 due to faulty overload
resolution with shared_ptrs and array types.

Instead of reverting that commit and reintroducing the possible misuse
of the buffer, exchange it completely with a std::vector<uint8>.