### PR TITLE
Fix digest authentication

### DIFF
--- a/src/xop/Authenticator.h
+++ b/src/xop/Authenticator.h
@@ -13,7 +13,7 @@ public:
 	Authenticator() {};
 	virtual ~Authenticator() {};
 
-  virtual bool Authenticate(std::shared_ptr<RtspRequest> request, std::string &nonce) = 0;
+  virtual bool Authenticate(std::shared_ptr<RtspRequest> request) = 0;
   virtual size_t GetFailedResponse(std::shared_ptr<RtspRequest> request, std::shared_ptr<char> buf, size_t size) = 0;
 
 private:

--- a/src/xop/DigestAuthenticator.cpp
+++ b/src/xop/DigestAuthenticator.cpp
@@ -16,11 +16,6 @@ DigestAuthenticator::~DigestAuthenticator()
 
 }
 
-std::string DigestAuthenticator::GetNonce()
-{
-	return md5::generate_nonce();
-}
-
 std::string DigestAuthenticator::GetResponse(std::string nonce, std::string cmd, std::string url)
 {
 	//md5(md5(<username>:<realm> : <password>) :<nonce> : md5(<cmd>:<url>))
@@ -32,13 +27,12 @@ std::string DigestAuthenticator::GetResponse(std::string nonce, std::string cmd,
 }
 
 bool DigestAuthenticator::Authenticate(
-    std::shared_ptr<RtspRequest> rtsp_request,
-    std::string &nonce)
+    std::shared_ptr<RtspRequest> rtsp_request)
 {
   std::string cmd = rtsp_request->MethodToString[rtsp_request->GetMethod()];
   std::string url = rtsp_request->GetRtspUrl();
 
-  if (nonce.size() > 0 && (GetResponse(nonce, cmd, url) == rtsp_request->GetAuthResponse())) {
+  if (nonce_.size() > 0 && (GetResponse(nonce_, cmd, url) == rtsp_request->GetAuthResponse())) {
     return true;
   } else {
 #if 0
@@ -52,6 +46,6 @@ size_t DigestAuthenticator::GetFailedResponse(
     std::shared_ptr<char> buf,
     size_t size)
 {
-  std::string nonce = md5::generate_nonce();
-  return rtsp_request->BuildUnauthorizedRes(buf.get(), size, realm_.c_str(), nonce.c_str());
+  nonce_ = md5::generate_nonce();
+  return rtsp_request->BuildUnauthorizedRes(buf.get(), size, realm_.c_str(), nonce_.c_str());
 }

--- a/src/xop/DigestAuthenticator.h
+++ b/src/xop/DigestAuthenticator.h
@@ -1,8 +1,8 @@
 //PHZ
 //2019-10-6
 
-#ifndef RTSP_DIGEST_AUTHENTICATION_H
-#define RTSP_DIGEST_AUTHENTICATION_H
+#ifndef RTSP_DIGEST_AUTHENTICATOR_H
+#define RTSP_DIGEST_AUTHENTICATOR_H
 
 #include "Authenticator.h"
 
@@ -27,17 +27,16 @@ public:
 	std::string GetPassword() const
 	{ return password_; }
 
-	std::string GetNonce();
 	std::string GetResponse(std::string nonce, std::string cmd, std::string url);
 
-  bool Authenticate(std::shared_ptr<RtspRequest> request, std::string &nonce);
-  size_t GetFailedResponse(std::shared_ptr<RtspRequest> request, std::shared_ptr<char> buf, size_t size);
+	bool Authenticate(std::shared_ptr<RtspRequest> request);
+	size_t GetFailedResponse(std::shared_ptr<RtspRequest> request, std::shared_ptr<char> buf, size_t size);
 
 private:
 	std::string realm_;
 	std::string username_;
 	std::string password_;
-
+	std::string nonce_;
 };
 
 }

--- a/src/xop/RtspConnection.cpp
+++ b/src/xop/RtspConnection.cpp
@@ -412,7 +412,7 @@ void RtspConnection::HandleCmdGetParamter()
 bool RtspConnection::HandleAuthentication()
 {
 	if (authenticator_ != nullptr && !has_auth_) {
-    if (authenticator_->Authenticate(rtsp_request_, _nonce)) {
+    if (authenticator_->Authenticate(rtsp_request_)) {
 			has_auth_ = true;
     } else {
       std::shared_ptr<char> res(new char[4096], std::default_delete<char[]>());


### PR DESCRIPTION
Hi.
I send you this piece of code to fix digest authentication.
The problem is that nonce is not saved.
So, when compared with the response, the verification fails.
