### PR TITLE
many: Change style of ifdef of Windows vs Unix

### DIFF
--- a/src/net/BufferWriter.cpp
+++ b/src/net/BufferWriter.cpp
@@ -115,9 +115,9 @@ int BufferWriter::Send(SOCKET sockfd, int timeout)
 			}
 		}
 		else if (ret < 0) {
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
 		if (errno == EINTR || errno == EAGAIN) 
-#elif defined(WIN32) || defined(_WIN32)
+#else /* Windows */
 			int error = WSAGetLastError();
 			if (error == WSAEWOULDBLOCK || error == WSAEINPROGRESS || error == 0)
 #endif

--- a/src/net/EventLoop.cpp
+++ b/src/net/EventLoop.cpp
@@ -60,7 +60,7 @@ void EventLoop::Loop()
 	{
 #if defined(__linux) || defined(__linux__)
 		std::shared_ptr<TaskScheduler> task_scheduler_ptr(new EpollTaskScheduler(n));
-#elif defined(WIN32) || defined(_WIN32) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#else /* not Linux */
 		std::shared_ptr<TaskScheduler> task_scheduler_ptr(new SelectTaskScheduler(n));
 #endif
 		task_schedulers_.push_back(task_scheduler_ptr);
@@ -73,9 +73,9 @@ void EventLoop::Loop()
 
 	for (auto iter : threads_) 
 	{
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
 
-#elif defined(WIN32) || defined(_WIN32) 
+#else /* Windows */ 
 		switch (priority) 
 		{
 		case TASK_SCHEDULER_PRIORITY_LOW:

--- a/src/net/NetInterface.cpp
+++ b/src/net/NetInterface.cpp
@@ -8,7 +8,7 @@ using namespace xop;
 
 std::string NetInterface::GetLocalIPAddress()
 {
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
     SOCKET sockfd = 0;
     char buf[512] = { 0 };
     struct ifconf ifconf;
@@ -43,7 +43,7 @@ std::string NetInterface::GetLocalIPAddress()
         }
     }
     return "0.0.0.0";
-#elif defined(WIN32) || defined(_WIN32)
+#else /* Windows */
     PIP_ADAPTER_INFO pIpAdapterInfo = new IP_ADAPTER_INFO();
     unsigned long size = sizeof(IP_ADAPTER_INFO);
 
@@ -81,8 +81,6 @@ std::string NetInterface::GetLocalIPAddress()
     }
 
     delete pIpAdapterInfo;
-    return "0.0.0.0";
-#else
     return "0.0.0.0";
 #endif
 }

--- a/src/net/Pipe.cpp
+++ b/src/net/Pipe.cpp
@@ -56,7 +56,7 @@ bool Pipe::Create()
 
 	SocketUtil::SetNonBlock(pipe_fd_[0]);
 	SocketUtil::SetNonBlock(pipe_fd_[1]);
-#elif defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#else /* Not Windows */
 	if (pipe2(pipe_fd_, O_NONBLOCK | O_CLOEXEC) < 0) {
 		return false;
 	}
@@ -68,7 +68,7 @@ int Pipe::Write(void *buf, int len)
 {
 #if defined(WIN32) || defined(_WIN32) 
     return ::send(pipe_fd_[1], (char *)buf, len, 0);
-#elif defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#else /* Not Windows */
     return ::write(pipe_fd_[1], buf, len);
 #endif 
 }
@@ -77,7 +77,7 @@ int Pipe::Read(void *buf, int len)
 {
 #if defined(WIN32) || defined(_WIN32) 
     return recv(pipe_fd_[0], (char *)buf, len, 0);
-#elif defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#else /* Not Windows */
     return ::read(pipe_fd_[0], buf, len);
 #endif 
 }
@@ -87,7 +87,7 @@ void Pipe::Close()
 #if defined(WIN32) || defined(_WIN32) 
 	closesocket(pipe_fd_[0]);
 	closesocket(pipe_fd_[1]);
-#elif defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#else /* Not Windows */
 	::close(pipe_fd_[0]);
 	::close(pipe_fd_[1]);
 #endif

--- a/src/net/SelectTaskScheduler.cpp
+++ b/src/net/SelectTaskScheduler.cpp
@@ -158,7 +158,7 @@ bool SelectTaskScheduler::HandleEvent(int timeout)
 	struct timeval tv = { timeout/1000, timeout%1000*1000 };
 	int ret = select((int)maxfd_+1, &fd_read, &fd_write, &fd_exp, &tv); 	
 	if (ret < 0) {
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
 	if(errno == EINTR) {
 		return true;
 	}					

--- a/src/net/SelectTaskScheduler.h
+++ b/src/net/SelectTaskScheduler.h
@@ -9,7 +9,7 @@
 #include <mutex>
 #include <unordered_map>
 
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
 #include <sys/select.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/src/net/Socket.h
+++ b/src/net/Socket.h
@@ -4,7 +4,7 @@
 #ifndef XOP_SOCKET_H
 #define XOP_SOCKET_H
 
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
 #include <sys/types.h>         
 #include <sys/socket.h>
 #include <sys/ioctl.h>
@@ -14,10 +14,13 @@
 #endif
 
 #if defined(__linux) || defined(__linux__) || defined(__FreeBSD__)
+/*
+ * ethernet.h is not specified by POSIX and is not present on NetBSD or OpenBSD.
+ */
 #include <net/ethernet.h>   
 #endif
 
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
 #include <net/route.h>  
 #include <netdb.h>
 #include <net/if.h>
@@ -29,7 +32,7 @@
 #define INVALID_SOCKET  (-1)
 #define SOCKET_ERROR    (-1) 
 
-#elif defined(WIN32) || defined(_WIN32) 
+#else /* Windows */ 
 #define FD_SETSIZE      1024
 #define WIN32_LEAN_AND_MEAN
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
@@ -40,8 +43,6 @@
 #define SHUT_RD 0
 #define SHUT_WR 1 
 #define SHUT_RDWR 2
-
-#else
 
 #endif
 

--- a/src/net/SocketUtil.cpp
+++ b/src/net/SocketUtil.cpp
@@ -23,10 +23,10 @@ bool SocketUtil::Bind(SOCKET sockfd, std::string ip, uint16_t port)
 
 void SocketUtil::SetNonBlock(SOCKET fd)
 {
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
     int flags = fcntl(fd, F_GETFL, 0);
     fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-#elif defined(WIN32) || defined(_WIN32)
+#else /* Windows */
     unsigned long on = 1;
     ioctlsocket(fd, FIONBIO, &on);
 #endif
@@ -34,24 +34,22 @@ void SocketUtil::SetNonBlock(SOCKET fd)
 
 void SocketUtil::SetBlock(SOCKET fd, int write_timeout)
 {
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
     int flags = fcntl(fd, F_GETFL, 0);
     fcntl(fd, F_SETFL, flags&(~O_NONBLOCK));
-#elif defined(WIN32) || defined(_WIN32)
+#else /* Windows */
     unsigned long on = 0;
     ioctlsocket(fd, FIONBIO, &on);
-#else
 #endif
     if(write_timeout > 0)
     {
 #ifdef SO_SNDTIMEO
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
     struct timeval tv = {write_timeout/1000, (write_timeout%1000)*1000};
     setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char*)&tv, sizeof tv);
-#elif defined(WIN32) || defined(_WIN32)
+#else /* Windows */
     unsigned long ms = (unsigned long)write_timeout;
     setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&ms, sizeof(unsigned long));
-#else
 #endif		
 #endif
 	}
@@ -168,9 +166,9 @@ int SocketUtil::GetPeerAddr(SOCKET sockfd, struct sockaddr_in *addr)
 
 void SocketUtil::Close(SOCKET sockfd)
 {
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
     ::close(sockfd);
-#elif defined(WIN32) || defined(_WIN32)
+#else /* Windows */
     ::closesocket(sockfd);
 #endif
 }

--- a/src/net/TaskScheduler.cpp
+++ b/src/net/TaskScheduler.cpp
@@ -1,5 +1,5 @@
 #include "TaskScheduler.h"
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
 #include <signal.h>
 #endif
 
@@ -36,7 +36,7 @@ TaskScheduler::~TaskScheduler()
 void TaskScheduler::Start()
 {
 #if 0
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
 	signal(SIGPIPE, SIG_IGN);
 	signal(SIGQUIT, SIG_IGN);
 	signal(SIGUSR1, SIG_IGN);

--- a/src/net/TcpSocket.cpp
+++ b/src/net/TcpSocket.cpp
@@ -71,12 +71,10 @@ bool TcpSocket::Connect(std::string ip, uint16_t port, int timeout)
 
 void TcpSocket::Close()
 {
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
     ::close(sockfd_);
-#elif defined(WIN32) || defined(_WIN32)
+#else /* Windows */
     closesocket(sockfd_);
-#else
-	
 #endif
 	sockfd_ = 0;
 }

--- a/src/net/Timestamp.cpp
+++ b/src/net/Timestamp.cpp
@@ -17,7 +17,7 @@ std::string Timestamp::Localtime()
     struct tm tm;
     localtime_s(&tm, &tt);
     stream << std::put_time(&tm, "%F %T");
-#elif  defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#else /* Not Windows */
     char buffer[200] = {0};
     std::string timeString;
     std::strftime(buffer, 200, "%F %T", std::localtime(&tt));

--- a/src/xop/rtsp.h
+++ b/src/xop/rtsp.h
@@ -51,17 +51,17 @@ public:
 		char ip[100] = { 0 };
 		char suffix[100] = { 0 };
 		uint16_t port = 0;
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
 		if (sscanf(url.c_str() + 7, "%[^:]:%hu/%s", ip, &port, suffix) == 3)
-#elif defined(WIN32) || defined(_WIN32)
+#else /* Windows */
 		if (sscanf_s(url.c_str() + 7, "%[^:]:%hu/%s", ip, 100, &port, suffix, 100) == 3)
 #endif
 		{
 			rtsp_url_info_.port = port;
 		}
-#if defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(_WIN32) /* not Windows */
 		else if (sscanf(url.c_str() + 7, "%[^/]/%s", ip, suffix) == 2)
-#elif defined(WIN32) || defined(_WIN32)
+#else /* Windows */
 		else if (sscanf_s(url.c_str() + 7, "%[^/]/%s", ip, 100, suffix, 100) == 2)
 #endif
 		{


### PR DESCRIPTION
There were many instances of an ifdef idiom checking for one of many Unix-like systems, and an else for Windows.  This idiom fails to build on a new Unix-like system and needs significant edits.

Replace the list of systems with a "if this system is not windows" and an else, intending to have no code change on any system in the prior list, and extending portability to Unix-like systems not in the prior list.

In several places, an else clause -- for systems that aren't in the list and aren't windows -- was removed.


This commit (and dropping extending the conditionals to NetBSD) has survived build testing on NetBSD, and I'm running it on NetBSD/aarch64, apparently ok.